### PR TITLE
Added quotes in case the XCode path has spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CLANG_SIMULATOR = xcrun --sdk iphonesimulator clang -Os -miphoneos-version-min=9.0 -isysroot `xcrun --sdk iphonesimulator --show-sdk-path` -arch i386 -arch x86_64 -fobjc-arc -fmodules
+CLANG_SIMULATOR = xcrun --sdk iphonesimulator clang -Os -miphoneos-version-min=9.0 -isysroot "`xcrun --sdk iphonesimulator --show-sdk-path`" -arch i386 -arch x86_64 -fobjc-arc -fmodules
 
 all: SBShortcutMenuSimulator.dylib
 


### PR DESCRIPTION
My XCode was named "XCode 7.app" and was breaking the make process because of the space in the path. This change fixes this case.
